### PR TITLE
Upgrade packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ cython_debug/
 
 # ctags
 tags
+
+# Pycharm
+.idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-apispec==5.1.1
-pip-chill==1.0.1
+apispec==6.6.0
+pip-chill==1.0.3
 pydantic==1.7.3
 pytest-tornado==0.8.1
 pytest-watch==4.2.0
-rope==0.18.0
-sortedcontainers==2.3.0
-tornado==6.1
-tox==3.24.4
-typed-ast==1.4.2
+rope==1.12.0
+sortedcontainers==2.4.0
+tornado==6.4
+tox==4.14.1
+typed-ast==1.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apispec==6.6.0
 pip-chill==1.0.3
-pydantic==1.7.3
+pydantic==2.6.4
 pytest-tornado==0.8.1
 pytest-watch==4.2.0
 rope==1.12.0

--- a/tests/api_spec/test_pydantic_fields_schema.py
+++ b/tests/api_spec/test_pydantic_fields_schema.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pydantic import Field
+from pydantic.v1 import Field
 from torn_open import AnnotatedHandler, Application, url
 
 @pytest.fixture

--- a/tests/api_spec/test_schema.py
+++ b/tests/api_spec/test_schema.py
@@ -1,5 +1,5 @@
 from tornado.web import url
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from torn_open import Application, AnnotatedHandler, RequestModel, ResponseModel
 

--- a/torn_open/annotated_handler.py
+++ b/torn_open/annotated_handler.py
@@ -11,7 +11,7 @@ from typing import (
 
 import tornado
 
-import pydantic
+import pydantic.v1 as pydantic
 
 from torn_open import types
 from torn_open import models

--- a/torn_open/api_spec/plugin.py
+++ b/torn_open/api_spec/plugin.py
@@ -1,7 +1,7 @@
 from typing import Dict, Tuple, Optional
 import inspect
 
-from pydantic import create_model
+from pydantic.v1 import create_model
 
 from apispec import BasePlugin
 from torn_open.types import is_optional, GenericAliases

--- a/torn_open/models.py
+++ b/torn_open/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class RequestModel(BaseModel):


### PR DESCRIPTION
## Context

This is a first iteration to start to contribute with the package maintenance.
I'm getting acquainted with the package code to migrate the Pydantic code form V1 to V2, possible V3.
I found the package very elegant. The way that it structures the Tornado handlers to receive and return (Request/Response) from Pydantic model instances, and from that generates API docs. It's pretty handy.

### Changes

In this PR the packages are upgraded to satisfy requirements from package checking services like Snyk. 

Signed-off-by: Andre Toscano <andre@keeplabs.com>